### PR TITLE
Adjust button for non-website pages and add sites.

### DIFF
--- a/src/cookie.html
+++ b/src/cookie.html
@@ -13,7 +13,7 @@
 </section>
 
 <p>
-    <span id="unknown">unknown site:</span>
+    <span id="unknown">Unknown Site</span>
     <span id="domain">example.com</span>
     <span id="managed"></span>
 </p>

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -42,17 +42,26 @@ async function main() {
     let {host} = new URL(tab.url);
     let domain = document.querySelector("#domain");
     domain.textContent = host;
-
+    let report = document.getElementById("report");
     let site = await getSite(host);
-    if (site) {
-        document.body.className = "managed";
+
+    if (tab.url.startsWith("about:") || tab.url.startsWith("file:") || tab.url == "") {
+        console.log("Condition met");
+        report.innerHTML = "This site is not a webpage...";
+        report.disabled = true;
+        report.style.display = "initial";
+        document.body.className = "unknown";
+    } else if (site) {
+        report.style.display = "none";
         let blocked = document.querySelector("#blocked");
         blocked.checked = site.blocked;
         blocked.addEventListener("change", actions);
         updateManaged(site);
     } else {
+        report.innerHTML = "Report Missing Site...";
+        report.disabled = false;
+        report.style.display = "initial";
         document.body.className = "unknown";
-        let report = document.querySelector("#report");
         report.addEventListener("click", actions);
     }
 }

--- a/src/sites.js
+++ b/src/sites.js
@@ -42,6 +42,16 @@ const sites = [
     },
     {
         // Working 9/11/2018 (M)
+        domain: "popularmechanics.com",
+        selector: "#_evidon-banner, #_evidon-background",
+    },
+    {
+        // Working 9/11/2018 (M)
+        domain: "thenextweb.com",
+        selector: ".cookieConsent-popOut",
+    },
+    {
+        // Working 9/11/2018 (M)
         domain: "independent.co.uk",
         selector: ".qc-cmp-ui-container.qc-cmp-showing",
     },

--- a/src/sites.js
+++ b/src/sites.js
@@ -40,14 +40,14 @@ const sites = [
         // Fixed 9/11/2018 (M)
         domain: "telegraph.co.uk",
         name: "_evidon_consent_cookie",
-        // Need to figure out current time sonversion for evidon format of date.
+        // Need to figure out current time conversion for evidon format of date.
         value: "{\"vendors\":{\"0\":[]},\"consent_date\":\"2018-08-23T18:33:49.352Z\"}",
     },
     {
         // Fixed 9/15/2018 (M)
         domain: "cnet.com",
         name: "_evidon_consent_cookie",
-        // Need to figure out current time sonversion for evidon format of date.
+        // Need to figure out current time conversion for evidon format of date.
         value: "{\"vendors\":{\"0\":[]},\"consent_date\":\"2018-08-23T18:33:49.352Z\"}",
     },
     {

--- a/src/sites.js
+++ b/src/sites.js
@@ -2,12 +2,14 @@
 
 /* exported sites, getSite */
 
+const time = new Date().getTime();
+
 const sites = [
     {
         // Working 9/11/2018 (M)
         domain: "mediapart.fr",
         name: "cc",
-        value: "{%22disagreement%22:[%22visit%22%2C%22ad%22]%2C%22creation%22:1535909178562%2C%22update%22:1535909178562}",
+        value: "{%22disagreement%22:[%22visit%22%2C%22ad%22]%2C%22creation%22:" + time + "%2C%22update%22:" + time + "}",
     },
     {
         // Working 9/11/2018 (M)
@@ -29,24 +31,53 @@ const sites = [
         value: "BOTRKYzOTRKYzABABBENBdAAAAAgWAAA",
     },
     {
+        // Working 9/17/2018 (M)
+        domain: "digitaltrends.com",
+        name: "CookieConsent",
+        value: "{stamp:'dv8/ZEvl7WmSKpF9zRuHOD/EcIGUL5sq/IiDrPYYe0q8SsOtlsV7ng=='%2Cnecessary:true%2Cpreferences:false%2Cstatistics:false%2Cmarketing:false%2Cver:1}",
+    },
+    {
         // Fixed 9/11/2018 (M)
         domain: "telegraph.co.uk",
         name: "_evidon_consent_cookie",
+        // Need to figure out current time sonversion for evidon format of date.
         value: "{\"vendors\":{\"0\":[]},\"consent_date\":\"2018-08-23T18:33:49.352Z\"}",
     },
     {
-        // Fixed 9/11/2018 (M)
+        // Fixed 9/15/2018 (M)
         domain: "cnet.com",
         name: "_evidon_consent_cookie",
+        // Need to figure out current time sonversion for evidon format of date.
         value: "{\"vendors\":{\"0\":[]},\"consent_date\":\"2018-08-23T18:33:49.352Z\"}",
     },
     {
-        // Working 9/11/2018 (M)
+        // Working 9/17/2018 (M)
         domain: "popularmechanics.com",
-        selector: "#_evidon-banner, #_evidon-background",
+        selector: "#_evidon-barrier-wrapper, #_evidon-banner, #_evidon-background",
     },
     {
-        // Working 9/11/2018 (M)
+        // Working 9/17/2018 (M)
+        domain: "mashable.com",
+        selector: "#_evidon-barrier-wrapper, #_evidon-banner, #_evidon-background",
+    },
+    {
+        // Working 9/17/2018 (M)
+        domain: "wired.com",
+        selector: "#_evidon_banner",
+    },
+    {
+        // Working 9/17/2018 (M)
+        // Note the .de
+        domain: "businessinsider.de",
+        selector: ".cc-window, .cc-banner, .cc-type-info, .cc-theme-block, .cc-bottom",
+    },
+    {
+        // Working 9/17/2018 (M)
+        domain: "eurogamer.net",
+        selector: ".cookie-gdpr, .cookie-bar",
+    },
+    {
+        // Working 9/17/2018 (M)
         domain: "thenextweb.com",
         selector: ".cookieConsent-popOut",
     },


### PR DESCRIPTION
In the update to the UI, button status (and text) will be adjusted to accommodate the user's experience on a page such as about:blank or file:///.....

Users will not be able to report from these pages.

7 more sites also added to the list and epoch time for an updated time value in cookies.