### PR TITLE
Block GDPR-Dialogs by their Consent-Provider

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,6 +14,8 @@
 
     "permissions": [
         "<all_urls>",
+        "webRequest",
+        "webRequestBlocking",
         "cookies",
         "storage",
         "tabs",
@@ -21,6 +23,7 @@
     ],
     "background": {
         "scripts": [
+            "src/consent_provider.js",
             "src/sites.js",
             "src/background.js"
         ]

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build": "npm test && web-ext build",
         "lint": "eslint src/*.js && web-ext lint",
         "list": "mocha --timeout 90000",
-        "start": "web-ext run --verbose",
+        "start": "web-ext run",
         "test": "npm run lint && npm run list"
     },
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "build": "npm test && web-ext build",
         "lint": "eslint src/*.js && web-ext lint",
         "list": "mocha --timeout 90000",
-        "start": "web-ext run",
+        "start": "web-ext run --verbose",
         "test": "npm run lint && npm run list"
     },
     "dependencies": {

--- a/src/background.js
+++ b/src/background.js
@@ -34,7 +34,13 @@ async function disable(site) {
 }
 
 let actions = {
-    async message({domain, blocked}) {
+    async message({domain, blocked, getDomain}) {
+        if (getDomain) {
+            const result = await getSite(getDomain);
+            console.log(result, getDomain, sites);
+            return result;
+        }
+
         console.log("message", sites);
         let site = await getSite(domain);
         if (!site) {

--- a/src/background.js
+++ b/src/background.js
@@ -35,10 +35,10 @@ async function disable(site) {
 
 let actions = {
     async message({domain, blocked}) {
-        console.log("message", sites)
+        console.log("message", sites);
         let site = await getSite(domain);
         if (!site) {
-            site = {blocked, manual: true, domain }
+            site = {blocked, manual: true, domain};
             sites.push(site);
         }
         site.storage = {blocked, manual: true};
@@ -70,14 +70,14 @@ let actions = {
 
 async function initRequestBlocker() {
     await browser.webRequest.onBeforeRequest.addListener(
-        async function (details) {
-            const tab = await browser.tabs.get(details.tabId)
-            const host = new URL(tab.url).host
+        async function(details) {
+            const tab = await browser.tabs.get(details.tabId);
+            const host = new URL(tab.url).host;
             const siteSettings = await getSite(host) || {blocked: true};
 
-            return { cancel: siteSettings.blocked }
+            return {cancel: siteSettings.blocked};
         },
-        { urls: domains },
+        {urls: domains},
         ["blocking"]
     );
 }

--- a/src/consent_provider.js
+++ b/src/consent_provider.js
@@ -1,0 +1,25 @@
+const domains = [
+	//quantcast
+	"https://static.quantcast.mgr.consensu.org/*/*-check.html",
+	"https://quantcast.mgr.consensu.org/cmp.js",
+	"https://api.quantcast.mgr.consensu.org/CookieAccess",
+	"https://static.quantcast.mgr.consensu.org/*/cmpui-popup.js",
+
+	//onetrust
+	"https://consent.trustarc.com/*",
+
+	"https://jadserve.postrelease.com/**",
+
+	"https://www.googletagmanager.com/gtm.js*",
+
+	"https://admiral.mgr.consensu.org/portal.html",
+
+
+	"https://*.nocookie.net/*/-/abtesting,oasis_blocking,universal_analytics_js,adengine2_top_js,tracking_opt_in_js,qualaroo_blocking_js",
+
+	//oath 
+	"https://guce.oath.com/collectConsent*",
+
+	// cookiebot
+	"https://consent.cookiebot.com/*",
+]

--- a/src/consent_provider.js
+++ b/src/consent_provider.js
@@ -1,25 +1,26 @@
+// eslint-disable-next-line
 const domains = [
-	//quantcast
-	"https://static.quantcast.mgr.consensu.org/*/*-check.html",
-	"https://quantcast.mgr.consensu.org/cmp.js",
-	"https://api.quantcast.mgr.consensu.org/CookieAccess",
-	"https://static.quantcast.mgr.consensu.org/*/cmpui-popup.js",
+    // quantcast
+    "https://static.quantcast.mgr.consensu.org/*/*-check.html",
+    "https://quantcast.mgr.consensu.org/cmp.js",
+    "https://api.quantcast.mgr.consensu.org/CookieAccess",
+    "https://static.quantcast.mgr.consensu.org/*/cmpui-popup.js",
 
-	//onetrust
-	"https://consent.trustarc.com/*",
+    // onetrust
+    "https://consent.trustarc.com/*",
 
-	"https://jadserve.postrelease.com/**",
+    "https://jadserve.postrelease.com/**",
 
-	"https://www.googletagmanager.com/gtm.js*",
+    "https://www.googletagmanager.com/gtm.js*",
 
-	"https://admiral.mgr.consensu.org/portal.html",
+    "https://admiral.mgr.consensu.org/portal.html",
 
 
-	"https://*.nocookie.net/*/-/abtesting,oasis_blocking,universal_analytics_js,adengine2_top_js,tracking_opt_in_js,qualaroo_blocking_js",
+    "https://*.nocookie.net/*/-/abtesting,oasis_blocking,universal_analytics_js,adengine2_top_js,tracking_opt_in_js,qualaroo_blocking_js",
 
-	//oath 
-	"https://guce.oath.com/collectConsent*",
+    // oath
+    "https://guce.oath.com/collectConsent*",
 
-	// cookiebot
-	"https://consent.cookiebot.com/*",
-]
+    // cookiebot
+    "https://consent.cookiebot.com/*",
+];

--- a/src/cookie.css
+++ b/src/cookie.css
@@ -102,11 +102,7 @@ input[type=checkbox]:checked {
     background: #369;
 }
 
-.unknown #managed, .unknown label, 
-.managed #unknown, .managed button, 
-.hide{
-    display: none;
-}
+
 
 .blocked:after {
     content: "first visited today, not trusted";

--- a/src/cookie.html
+++ b/src/cookie.html
@@ -2,7 +2,6 @@
 <head>
     <meta charset="utf-8">
     <link rel="stylesheet" href="cookie.css"/>
-    <script src="sites.js"></script>
     <script src="cookie.js" defer></script>
 </head>
 

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -62,18 +62,18 @@ async function main() {
         || tab.url.startsWith("view-source:") || tab.url == "") {
         isWebsite = false;
         updateSecondary(isWebsite);
-    } else
-    if (site) {
+    } else {
         let blocked = document.querySelector("#blocked");
-        blocked.checked = site.blocked;
+        blocked.checked = (site || {blocked: true}).blocked;
         blocked.addEventListener("change", actions);
         updateManaged(site);
-    } else {
-        isWebsite = true;
-        let report = document.querySelector("#report");
-        document.body.className = "unknown";
-        report.addEventListener("click", actions);
-        updateSecondary(isWebsite);
+        if (!site) {
+            isWebsite = true;
+            let report = document.querySelector("#report");
+            document.body.className = "unknown";
+            report.addEventListener("click", actions);
+            updateSecondary(isWebsite);
+        }
     }
 }
 

--- a/src/cookie.js
+++ b/src/cookie.js
@@ -22,6 +22,15 @@ function updateSecondary(isWebsite) {
     document.querySelector("#management").classList.toggle("managed", false);
 }
 
+// new consent_provider based blocking allows for dynamic adding of sites.
+// Therefore the sites array can change. This function establishes a Message-Channel to background.js
+// to retrive getSite(domain);
+async function getSite(domain) {
+    return await browser.runtime.sendMessage({
+        getDomain: domain,
+    });
+}
+
 let actions = {
     async blocked(e) {
         let domain = document.querySelector("#domain").textContent;

--- a/test/blocklist.json
+++ b/test/blocklist.json
@@ -10,5 +10,14 @@
     {
         "domain": "index.hr",
         "dialog": "Kolačiće upotrebljavamo"
+    },
+    {
+        "domain": "techcrunch.com",
+        "url": "http://techcrunch.com/?lang=en",
+        "dialog": "Select 'OK' to allow Oath and our partners to use your data"
+    },
+    {
+        "domain": "theatlantic.com",
+        "dialog": "Please click \"I Agree\" to accept this use of your data"
     }
 ]

--- a/test/test-list.js
+++ b/test/test-list.js
@@ -14,7 +14,7 @@ const driver = new Builder().forBrowser("firefox").build();
 async function getPageText(url) {
     await driver.executeScript(function(url) {window.location.href=url}, url)
     //await driver.get(url);
-    await driver.sleep(5000);
+    await driver.sleep(10000);
     let body = await driver.wait(until.elementLocated(By.tagName("body")), 10000);
     return await body.getText();
 }

--- a/test/test-list.js
+++ b/test/test-list.js
@@ -14,7 +14,7 @@ const driver = new Builder().forBrowser("firefox").build();
 async function getPageText(url) {
     await driver.executeScript(function(url) {window.location.href=url}, url)
     //await driver.get(url);
-    await driver.sleep(10000);
+    await driver.sleep(15000);
     let body = await driver.wait(until.elementLocated(By.tagName("body")), 10000);
     return await body.getText();
 }


### PR DESCRIPTION
many websites use consent provider (like etrust) blocking request to those websites results in the dialogs not being shown.
